### PR TITLE
fix: incorrect web shoe asset URL, in step 3.1 of 3D Display lesson

### DIFF
--- a/src/lessons/1_3DDisplay/README.md
+++ b/src/lessons/1_3DDisplay/README.md
@@ -193,7 +193,7 @@ Result:
 export function init() {
   // ...
   const loader = new GLTFLoader();
-  loader.load("assets/shoe/shoe.gltf", (model) => {
+  loader.load("./shoe.gltf", (model) => {
     display(model.scene, canvas, width, height);
   });
 ```


### PR DESCRIPTION
# Bug 🦟

The web asset URL in step 3.1 of the 3D Display lesson is wrong.

## Fix 🔧

This PR corrects it 🫡
