### PR TITLE
fix: get `context.canvas` dimensions, in step 4.4 of 3D display tut

### DIFF
--- a/src/lessons/1_3DDisplay/README.md
+++ b/src/lessons/1_3DDisplay/README.md
@@ -265,6 +265,8 @@ useEffect(() => {
 4.4 Setup a scene.  
 📁 `3DPreview.tsx`
 ```ts
+const { width, height } = context.canvas;
+
 const scene = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
 camera.position.z = 0.3;


### PR DESCRIPTION
# Bug 🦟

How one gets the `context.canvas` width and height isn't mentioned, in step 4.4 of the 3D display tutorial.

## Fix 🔧

This pull request adds a statement getting both from `context.canvas`, making this step copy-and-pasteable, like the rest of the tutorial. 🫡